### PR TITLE
SearchableによるModelインデックスの自動更新設定を削除

### DIFF
--- a/lib/palette/elastic_search/searchable.rb
+++ b/lib/palette/elastic_search/searchable.rb
@@ -22,18 +22,6 @@ module Palette
       included do
         include ::Elasticsearch::Model
 
-        after_commit on: [:create] do
-          self.__elasticsearch__.palette_index_document if ::Palette::ElasticSearch.configuration.run_callbacks
-        end
-
-        after_commit on: [:update] do
-          self.__elasticsearch__.palette_update_document if ::Palette::ElasticSearch.configuration.run_callbacks
-        end
-
-        after_commit on: [:destroy] do
-          self.__elasticsearch__.palette_delete_document if ::Palette::ElasticSearch.configuration.run_callbacks
-        end
-
         index_name { "#{Rails.env.downcase.underscore}_#{self.connection.current_database}_#{self.table_name.underscore}" }
         document_type self.table_name.underscore.singularize
 

--- a/spec/palette/elastic_search_spec.rb
+++ b/spec/palette/elastic_search_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Palette::ElasticSearch do
     expect(Palette::ElasticSearch::VERSION).not_to be nil
   end
 
+  # @note callback indexingの自動設定削除が完了したら消す
   describe 'callbacks' do
     let(:user) do
       User.new.tap do |user|
@@ -41,7 +42,7 @@ RSpec.describe Palette::ElasticSearch do
         include_context 'configured to true'
 
         specify 'run callbacks' do
-          expect(user.__elasticsearch__).to receive(:index_document)
+          expect(user.__elasticsearch__).not_to receive(:index_document)
           subject
         end
       end
@@ -64,7 +65,7 @@ RSpec.describe Palette::ElasticSearch do
         include_context 'configured to true'
 
         specify 'run callbacks' do
-          expect(user.__elasticsearch__).to receive(:update_document)
+          expect(user.__elasticsearch__).not_to receive(:update_document)
           subject
         end
       end
@@ -87,7 +88,7 @@ RSpec.describe Palette::ElasticSearch do
         include_context 'configured to true'
 
         specify 'run callbacks' do
-          expect(user.__elasticsearch__).to receive(:delete_document)
+          expect(user.__elasticsearch__).not_to receive(:delete_document)
           subject
         end
       end

--- a/spec/palette/elastic_search_spec.rb
+++ b/spec/palette/elastic_search_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Palette::ElasticSearch do
       context 'run_callbacks configured to true' do
         include_context 'configured to true'
 
-        specify 'run callbacks' do
+        specify 'not run callbacks' do
           expect(user.__elasticsearch__).not_to receive(:index_document)
           subject
         end
@@ -50,7 +50,7 @@ RSpec.describe Palette::ElasticSearch do
       context 'run_callbacks configured to false' do
         include_context 'configured to false'
 
-        specify 'run callbacks' do
+        specify 'not run callbacks' do
           expect(user.__elasticsearch__).not_to receive(:index_document)
           subject
         end
@@ -64,7 +64,7 @@ RSpec.describe Palette::ElasticSearch do
       context 'run_callbacks configured to true' do
         include_context 'configured to true'
 
-        specify 'run callbacks' do
+        specify 'not run callbacks' do
           expect(user.__elasticsearch__).not_to receive(:update_document)
           subject
         end
@@ -73,7 +73,7 @@ RSpec.describe Palette::ElasticSearch do
       context 'run_callbacks configured to false' do
         include_context 'configured to false'
 
-        specify 'run callbacks' do
+        specify 'not run callbacks' do
           expect(user.__elasticsearch__).not_to receive(:update_document)
           subject
         end
@@ -87,7 +87,7 @@ RSpec.describe Palette::ElasticSearch do
       context 'run_callbacks configured to true' do
         include_context 'configured to true'
 
-        specify 'run callbacks' do
+        specify 'not run callbacks' do
           expect(user.__elasticsearch__).not_to receive(:delete_document)
           subject
         end
@@ -96,7 +96,7 @@ RSpec.describe Palette::ElasticSearch do
       context 'run_callbacks configured to false' do
         include_context 'configured to false'
 
-        specify 'run callbacks' do
+        specify 'not run callbacks' do
           expect(user.__elasticsearch__).not_to receive(:delete_document)
           subject
         end


### PR DESCRIPTION
### Searchable Concernのcallback設定削除

Elasticsearchのインデックス更新を同期的制約のある一部を覗き非同期処理化する。
本ライブラリ側でSearchableを定義したActiveRecordモデルに自動的にレコード更新時の同期的コールバック設定をしてしまっているため設定を削除。
アプリケーション側でindexをもつモデル自身の更新に関しても、index更新するwisper設定をするようにする。


ユニットテスト実行結果
![image](https://user-images.githubusercontent.com/4545820/66638423-e6c8c680-ec4f-11e9-9728-8a52d85fa401.png)

