### PR TITLE
ngramでトークナイズする際に記号を除外しないようにする

### DIFF
--- a/lib/palette/elastic_search/searchable.rb
+++ b/lib/palette/elastic_search/searchable.rb
@@ -57,13 +57,13 @@ module Palette
                            type: 'ngram',
                            min_gram: 2,
                            max_gram: 2,
-                           token_chars: %W(letter digit)
+                           token_chars: %W(letter digit symbol)
                          },
                          n_gram: {
                            type: 'ngram',
                            min_gram: 1,
                            max_gram: 40,
-                           token_chars: %W(letter digit punctuation)
+                           token_chars: %W(letter digit punctuation symbol)
                          }
                        },
                        analyzer: {


### PR DESCRIPTION
`○` や `$`、`√` 等の記号が除外されてしまうため、token_chars に `symbol` を追加しました。