### PR TITLE
rescue Elasticsearch::Transport::Transport::Errors::NotFound on recor…

### DIFF
--- a/lib/palette/elastic_search/indexing.rb
+++ b/lib/palette/elastic_search/indexing.rb
@@ -17,6 +17,7 @@ module Palette
         def palette_update_document
           begin
             # call update_document_attributes directly so as not to call index_document automatically
+            # @see https://github.com/elastic/elasticsearch-rails/blob/v5.1.0/elasticsearch-model/lib/elasticsearch/model/indexing.rb#L400
             update_document_attributes(self.as_indexed_json, {retry_on_conflict: 1})
           rescue ::Elasticsearch::Transport::Transport::Errors::NotFound
             # check whether record has already been destroyed

--- a/lib/palette/elastic_search/indexing.rb
+++ b/lib/palette/elastic_search/indexing.rb
@@ -18,6 +18,9 @@ module Palette
           begin
             update_document(retry_on_conflict: 1)
           rescue ::Elasticsearch::Transport::Transport::Errors::NotFound
+            # check whether record has already been destroyed
+            palette_delete_document if self.class.find_by(id: self.id).blank?
+
             palette_index_document
           rescue ::Elasticsearch::Transport::Transport::Errors::Conflict => e
             ::Palette::ElasticSearch::Logger.instance.error e
@@ -27,6 +30,8 @@ module Palette
         def palette_delete_document
           begin
             delete_document
+          rescue ::Elasticsearch::Transport::Transport::Errors::NotFound => e
+            ::Palette::ElasticSearch::Logger.instance.error e
           rescue ::Elasticsearch::Transport::Transport::Errors::Conflict => e
             ::Palette::ElasticSearch::Logger.instance.error e
           end

--- a/lib/palette/elastic_search/indexing.rb
+++ b/lib/palette/elastic_search/indexing.rb
@@ -16,10 +16,14 @@ module Palette
 
         def palette_update_document
           begin
-            update_document(retry_on_conflict: 1)
+            # call update_document_attributes directly so as not to call index_document automatically
+            update_document_attributes(self.as_indexed_json, {retry_on_conflict: 1})
           rescue ::Elasticsearch::Transport::Transport::Errors::NotFound
             # check whether record has already been destroyed
-            palette_delete_document if self.class.find_by(id: self.id).blank?
+            unless self.class.exists?(id: self.id)
+              palette_delete_document
+              return
+            end
 
             palette_index_document
           rescue ::Elasticsearch::Transport::Transport::Errors::Conflict => e

--- a/spec/palette/elastic_search_spec.rb
+++ b/spec/palette/elastic_search_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Palette::ElasticSearch do
       User.new.tap do |user|
         # do not request toward es instance
         allow(user.__elasticsearch__).to receive(:index_document)
-        allow(user.__elasticsearch__).to receive(:update_document)
+        allow(user.__elasticsearch__).to receive(:update_document_attributes)
         allow(user.__elasticsearch__).to receive(:delete_document)
       end
     end
@@ -64,7 +64,7 @@ RSpec.describe Palette::ElasticSearch do
         include_context 'configured to true'
 
         specify 'run callbacks' do
-          expect(user.__elasticsearch__).to receive(:update_document)
+          expect(user.__elasticsearch__).to receive(:update_document_attributes)
           subject
         end
       end
@@ -73,7 +73,7 @@ RSpec.describe Palette::ElasticSearch do
         include_context 'configured to false'
 
         specify 'run callbacks' do
-          expect(user.__elasticsearch__).not_to receive(:update_document)
+          expect(user.__elasticsearch__).not_to receive(:update_document_attributes)
           subject
         end
       end


### PR DESCRIPTION
modified to call palette_delete_document if palette_update_document is called and it returns 404 error but record has been already deleted.