### PR TITLE
use custom preference as default

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    palette-elastic_search (0.4.17)
+    palette-elastic_search (0.4.21)
       activesupport
       elasticsearch-model (~> 5.0)
       elasticsearch-rails (~> 5.0)
@@ -58,10 +58,12 @@ GEM
       faraday
       multi_json
     erubi (1.9.0)
-    faraday (1.0.1)
-      multipart-post (>= 1.2, < 3)
+    faraday (2.1.0)
+      faraday-net_http (~> 2.0)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (2.0.1)
     hashdiff (1.0.0)
-    hashie (4.1.0)
+    hashie (5.0.0)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     loofah (2.3.1)
@@ -70,9 +72,8 @@ GEM
     method_source (0.9.2)
     mini_portile2 (2.4.0)
     minitest (5.12.2)
-    multi_json (1.14.1)
-    multipart-post (2.1.1)
-    newrelic_rpm (6.10.0.364)
+    multi_json (1.15.0)
+    newrelic_rpm (8.3.0)
     nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     pry (0.12.2)
@@ -119,6 +120,7 @@ GEM
     rspec-support (3.9.0)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
+    ruby2_keywords (0.0.5)
     safe_yaml (1.0.5)
     sqlite3 (1.4.1)
     thor (0.20.3)
@@ -135,7 +137,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord
-  bundler (~> 2.1.4)
+  bundler (~> 2.2.30)
   palette-elastic_search!
   pry-rails
   rake (~> 13.0)
@@ -146,4 +148,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.1.4
+   2.2.30

--- a/lib/palette/elastic_search/searchable.rb
+++ b/lib/palette/elastic_search/searchable.rb
@@ -11,11 +11,11 @@ module Palette
       class_methods do
         include ::Palette::ElasticSearch::Indexing::ClassMethods
 
-        # Set preference to _primary_first as default
+        # Set custom value preference as default
         # To ensure results consistency over pages.
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/5.0/search-request-preference.html#search-request-preference
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-preference.html
         def search(query_or_payload, options={})
-          __elasticsearch__.search query_or_payload, options.reverse_merge(preference: '_primary_first')
+          __elasticsearch__.search query_or_payload, options.reverse_merge(preference: self.table_name)
         end
       end
 

--- a/spec/palette/elastic_search/scrolling_spec.rb
+++ b/spec/palette/elastic_search/scrolling_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Palette::ElasticSearch::Scrolling do
       scroll_stub
     end
     let(:search_stub) do
-      stub_request(:get, "http://dummy-host/development_sample_database_users/user/_search?preference=_primary_first&scroll=5m&size=1")
+      stub_request(:get, "http://dummy-host/development_sample_database_users/user/_search?preference=users&scroll=5m&size=1")
         .to_return(status: 200, body: search_stub_response.to_json, headers: {content_type: 'application/json'})
     end
     let(:scroll_stub) do


### PR DESCRIPTION
`_primary_first` preference will be deprecated from es version 6.1, so fixed to be used custom value preference as default.


reference
https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-preference.html