### PR TITLE
current_indicesで数字の桁数も見るように

### DIFF
--- a/lib/palette/elastic_search/indexing.rb
+++ b/lib/palette/elastic_search/indexing.rb
@@ -68,7 +68,7 @@ module Palette
         private
 
         def current_indices
-          self.__elasticsearch__.client.indices.get_aliases.keys.grep(/^#{self.index_name}/)
+          self.__elasticsearch__.client.indices.get_aliases.keys.grep(/^#{self.index_name}_[0-9]{8}_[0-9]{6}/)
         end
 
         def get_new_index_name


### PR DESCRIPTION
current_indicesでindex_nameしか見ていなかったため関係のないモデルのindexも引っかかっていた。
そのため数字の桁数も形式チェックに含めた。