### PR TITLE
operating_guide用のanalyzerを追加

### DIFF
--- a/lib/palette/elastic_search/searchable.rb
+++ b/lib/palette/elastic_search/searchable.rb
@@ -61,7 +61,7 @@ module Palette
                          },
                          deca_gram: {
                            type: 'ngram',
-                           min_gram: 2,
+                           min_gram: 1,
                            max_gram: 10,
                            token_chars: %W(letter digit punctuation symbol)
                          },

--- a/lib/palette/elastic_search/searchable.rb
+++ b/lib/palette/elastic_search/searchable.rb
@@ -59,6 +59,12 @@ module Palette
                            max_gram: 2,
                            token_chars: %W(letter digit symbol)
                          },
+                         deca_gram: {
+                           type: 'ngram',
+                           min_gram: 2,
+                           max_gram: 10,
+                           token_chars: %W(letter digit punctuation symbol)
+                         },
                          n_gram: {
                            type: 'ngram',
                            min_gram: 1,
@@ -85,6 +91,10 @@ module Palette
                          },
                          bigram: {
                            tokenizer: 'bi_gram',
+                           char_filter: %W(my_icu_normalizer space_trimmer hyphen_normalizer)
+                         },
+                         decagram: {
+                           tokenizer: 'deca_gram',
                            char_filter: %W(my_icu_normalizer space_trimmer hyphen_normalizer)
                          },
                          ngram: {


### PR DESCRIPTION
## 概要
操作マニュアルの検索機能用のanalyzerを追加

## 関連URL
* https://github.com/palettecloud/palette/pull/11216

## 対応内容
* 操作マニュアルの検索に関して、`ngram`だとメモリが足りないため、`min: 2, max: 10`のサイズのanalyzer、`decagram`を追加する
* decaはbigramにちなんで、10の接頭語である`deca`を名前に採用
